### PR TITLE
Add support for SLACKINVITER_MAINTENANCE flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,11 +56,13 @@ type Specification struct {
 	SlackToken     string `required:"true"`
 	CocUrl         string `required:"false" default:"http://coc.golangbridge.org/"`
 	EnforceHTTPS   bool
-	Debug          bool // toggles nlopes/slack client's debug flag
+	Debug          bool   // toggles nlopes/slack client's debug flag
+	Maintenance    bool   `required:"false"`
+	SupportEmail   string `required:"false" default:"support@gobridge.org"`
 }
 
 func init() {
-	var showUsage = flag.Bool("h", false, "Show usage")
+	showUsage := flag.Bool("h", false, "Show usage")
 	flag.Parse()
 
 	if *showUsage {
@@ -212,14 +214,18 @@ func homepage(w http.ResponseWriter, r *http.Request) {
 			SiteKey,
 			UserCount,
 			ActiveCount string
-			Team   *team
-			CocUrl string
+			Team            *team
+			CocUrl          string
+			MaintenanceMode bool
+			SupportEmail    string
 		}{
 			c.CaptchaSitekey,
 			userCount.String(),
 			activeUserCount.String(),
 			ourTeam,
 			c.CocUrl,
+			c.Maintenance,
+			c.SupportEmail,
 		},
 	)
 	if err != nil {

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -8,9 +8,19 @@
     <body>
         <div class="splash">
             <div class="logos">
+              {{ if not .MaintenanceMode  -}}
                 <div class="logo org"></div>
+              {{ end -}}
                 <div class="logo slack"></div>
             </div>
+            {{ if .MaintenanceMode -}}
+            <p class="status">We're experiencing issues with our invite form at this time.</p><br/>
+            {{ if .SupportEmail -}}
+            <p>Please email <a href="sendto:{{ .SupportEmail }}">{{ .SupportEmail }}<a> to request an invite.</p>
+            {{ else -}}
+            <p>Please check back later!</p>
+            {{ end -}}
+            {{ else -}}
             <p>Join <b>{{.Team.Name}}</b> on Slack.</p>
             <p class="status">
                 <b class="active">{{.ActiveCount}}</b> users online now of <b class="total">{{.UserCount}}</b> registered.
@@ -32,12 +42,13 @@
             <p class="signin">
                 or <a href="https://{{.Team.Domain}}.slack.com" target="_top">sign in</a>.
             </p>
+            {{ end -}}
             <footer>
                 powered by <a href="http://github.com/flexd/slackinviter" target="_blank">slackinviter... totally ripping off the slackin css :-)</a>
             </footer>
             <style>
                 .splash {
-                    width: 300px;
+                    width: 400px;
                     margin: 200px auto;
                     text-align: center;
                     font-family: "Helvetica Neue", Helvetica, Arial


### PR DESCRIPTION
This renders a separate index view, where it tells you to reach out to
`$SLACKINVITER_SUPPORTEMAIL` to reqeust an invite. If that environment variable
is set to empty string, it tells users just to check back later.